### PR TITLE
feat(address): add Address.fromXpub() for deriving addresses from xpub

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,37 @@ addr.toTokenAddress()             // bitcoincash:zqz95enwd6qdcy5wnf05hp590sjjknw
 addr.toLegacyAddress()            // 1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2
 ```
 
+### Derive Addresses from xpub
+```javascript
+import Watchtower, { Address } from 'watchtower-cash-js'
+const watchtower = new Watchtower()
+
+const xpub = 'xpub6ByHsPNSQXTWZ7PLESMY2FufyYWtLXagSUpMQq7Un96SiThZH2iJB1X7pwviH1WtKVeDP6K8d6xxFzzoaFzF3s8BKCZx8oEDdDkNnp4owAZ'
+const addressIndex = 0
+
+// Returns { receiving: '<bch-address>', change: '<bch-address>' }
+const addresses = Address.fromXpub(xpub, addressIndex)
+
+// For chipnet (testnet)
+const chipnetAddresses = Address.fromXpub(xpub, addressIndex, true)
+
+// Subscribe the derived addresses to Watchtower
+const subscribeData = {
+  projectId: '0000-0000-0000',
+  addresses: {
+    receiving: addresses.receiving,
+    change: addresses.change
+  },
+  walletHash: 'your-wallet-hash',
+  addressIndex: addressIndex,
+  webhookUrl: 'https://xxx.com/webhook-call-receiver'
+}
+
+watchtower.subscribe(subscribeData).then(result => {
+  console.log(result)
+})
+```
+
 ### API Reference
 
 #### `Watchtower`
@@ -335,6 +366,7 @@ Import separately: `import { Address } from 'watchtower-cash-js'`
 
 | Method | Returns |
 |--------|---------|
+| `Address.fromXpub(xpub, addressIndex?, isChipnet?)` | `{ receiving: string, change: string }` |
 | `isCashAddress()` | `boolean` |
 | `isMainnetCashAddress()` | `boolean` |
 | `isTestnetCashAddress()` | `boolean` |

--- a/src/address/index.test.ts
+++ b/src/address/index.test.ts
@@ -1,5 +1,27 @@
 import Address from "./index.js";
 
+test('Test Address.fromXpub', () => {
+  // xpub for m/44'/145'/0' derived from mnemonic:
+  // "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+  const xpub = 'xpub6ByHsPNSQXTWZ7PLESMY2FufyYWtLXagSUpMQq7Un96SiThZH2iJB1X7pwviH1WtKVeDP6K8d6xxFzzoaFzF3s8BKCZx8oEDdDkNnp4owAZ'
+
+  const result0 = Address.fromXpub(xpub, 0)
+  expect(result0.receiving).toBe('bitcoincash:qqyx49mu0kkn9ftfj6hje6g2wfer34yfnq5tahq3q6')
+  expect(result0.change).toBe('bitcoincash:qr8aeharupyrmhfu0d4tdmsnc5y8cfk47y6qrsjsrx')
+
+  const result1 = Address.fromXpub(xpub, 1)
+  expect(result1.receiving).toBe('bitcoincash:qp8sfdhgjlq68hlzka9lcsxtcnvuvnd0xqxugfzzc5')
+  expect(result1.change).toBe('bitcoincash:qr88m3rp5nd5aerz5rh9lzly9u5pevykagwscmjk0c')
+
+  // chipnet
+  const chipnetResult = Address.fromXpub(xpub, 0, true)
+  expect(chipnetResult.receiving).toBe('bchtest:qqyx49mu0kkn9ftfj6hje6g2wfer34yfnqseeszx8x')
+  expect(chipnetResult.change).toBe('bchtest:qr8aeharupyrmhfu0d4tdmsnc5y8cfk47y7j8hs8y6')
+
+  // invalid xpub
+  expect(() => Address.fromXpub('invalid-xpub')).toThrow()
+})
+
 test('Test Address', () => {
   const address = new Address("bitcoincash:qqs7szj7r600ykzfpjs6xl8dj2u06as43qky0luk4s");
   expect(address.toCashAddress()).toBe("bitcoincash:qqs7szj7r600ykzfpjs6xl8dj2u06as43qky0luk4s");

--- a/src/address/index.test.ts
+++ b/src/address/index.test.ts
@@ -20,6 +20,9 @@ test('Test Address.fromXpub', () => {
 
   // invalid xpub
   expect(() => Address.fromXpub('invalid-xpub')).toThrow()
+
+  // negative addressIndex
+  expect(() => Address.fromXpub(xpub, -1)).toThrow('addressIndex must be non-negative')
 })
 
 test('Test Address', () => {

--- a/src/address/index.ts
+++ b/src/address/index.ts
@@ -15,7 +15,18 @@ import {
 } from "@bitauth/libauth";
 
 export default class Address {
+  /**
+   * Derive receiving and change addresses from an account-level xpub.
+   * @param xpub - The extended public key (xpub) at account level (e.g. m/44'/145'/0')
+   * @param addressIndex - The address index to derive (default: 0)
+   * @param isChipnet - Whether to generate chipnet (testnet) addresses (default: false)
+   * @returns Object containing receiving and change addresses
+   */
   static fromXpub (xpub: string, addressIndex = 0, isChipnet = false): { receiving: string; change: string } {
+    if (addressIndex < 0) {
+      throw new Error('addressIndex must be non-negative')
+    }
+
     const decoded = decodeHdPublicKey(xpub)
     if (typeof decoded === 'string') {
       throw new Error(decoded)

--- a/src/address/index.ts
+++ b/src/address/index.ts
@@ -8,10 +8,43 @@ import {
   cashAddressTypeBitsToType,
   decodeBase58AddressFormat,
   cashAddressToLockingBytecode,
-  lockingBytecodeToBase58Address
+  lockingBytecodeToBase58Address,
+  decodeHdPublicKey,
+  deriveHdPublicNodeChild,
+  hash160,
 } from "@bitauth/libauth";
 
 export default class Address {
+  static fromXpub (xpub: string, addressIndex = 0, isChipnet = false): { receiving: string; change: string } {
+    const decoded = decodeHdPublicKey(xpub)
+    if (typeof decoded === 'string') {
+      throw new Error(decoded)
+    }
+
+    const accountNode = decoded.node
+    const receivingNode = deriveHdPublicNodeChild(deriveHdPublicNodeChild(accountNode, 0), addressIndex)
+    const changeNode = deriveHdPublicNodeChild(deriveHdPublicNodeChild(accountNode, 1), addressIndex)
+
+    const receivingHash = hash160(receivingNode.publicKey)
+    const changeHash = hash160(changeNode.publicKey)
+
+    const prefix = isChipnet ? CashAddressNetworkPrefix.testnet : CashAddressNetworkPrefix.mainnet
+
+    const receiving = encodeCashAddress({
+      prefix,
+      type: CashAddressType.p2pkh,
+      payload: receivingHash
+    }).address
+
+    const change = encodeCashAddress({
+      prefix,
+      type: CashAddressType.p2pkh,
+      payload: changeHash
+    }).address
+
+    return { receiving, change }
+  }
+
   constructor (public address) {
     this.address = address
   }


### PR DESCRIPTION
## Summary
- Adds `Address.fromXpub()` static method to generate receiving and change Bitcoin Cash addresses from an account-level xpub (e.g. exported from Paytaca wallet).
- Derives addresses per BIP44 path: `0/i` for receiving, `1/i` for change.
- Supports both mainnet and chipnet (testnet) via optional `isChipnet` flag.
- Adds unit tests and updates README with usage example.

## Changes
- `src/address/index.ts` — new `fromXpub()` method
- `src/address/index.test.ts` — tests for mainnet, chipnet, and invalid xpub
- `README.md` — usage example and API reference